### PR TITLE
Make vector icons optional

### DIFF
--- a/Icon.js
+++ b/Icon.js
@@ -2,6 +2,7 @@
 * @flow
 */
 import React from 'react';
+import { Text } from 'react-native';
 
 let MaterialIcons;
 

--- a/Icon.js
+++ b/Icon.js
@@ -1,0 +1,44 @@
+/*
+* @flow
+*/
+import React from 'react';
+
+let MaterialIcons;
+
+try {
+  // Optionally require vector-icons
+  MaterialIcons = require('react-native-vector-icons/MaterialIcons').default;
+} catch (e) {
+  MaterialIcons = ({ name, color, size, style, ...rest }) => {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Tried to use the icon '${name}' in a component from 'react-navigation-header-buttons', but 'react-native-vector-icons' is not installed. To remove this warning, install 'react-native-vector-icons'.`
+    );
+
+    return (
+      <Text {...rest} style={[{ color, fontSize: size }, style]}>
+        □
+      </Text>
+    );
+  };
+}
+
+type Props = {
+  name: string,
+  color: string,
+  size: number,
+  style: Object,
+};
+const Icon = ({ name, color, size, style, ...rest }: Props) => {
+  return (
+    <MaterialIcons
+      {...rest}
+      name={name}
+      color={color}
+      size={size}
+      style={style}
+    />
+  );
+};
+
+export default Icon;

--- a/OverflowButton.js
+++ b/OverflowButton.js
@@ -10,9 +10,8 @@ import {
   ActionSheetIOS,
   Platform,
 } from 'react-native';
-// TODO import based on global.Expo?
-import Icon from 'react-native-vector-icons/MaterialIcons';
 import { HeaderButton } from './HeaderButton';
+import Icon from './Icon';
 
 export const textTransformer = (label: string) =>
   Platform.OS === 'ios' ? label.charAt(0).toUpperCase() + label.substr(1) : label.toUpperCase();

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Available via expo [here](https://expo.io/@vonovak/navbar-buttons-demo)
 
 `yarn add react-navigation-header-buttons`
 
+##### Tip
+
+If you don't want to install & use vector icons in OverflowIcon, you can use [babel-plugin-optional-require](https://github.com/satya164/babel-plugin-optional-require) to opt-out.
+
 #### Quick Example
 
 ```


### PR DESCRIPTION
Same as `react-native-paper`'s PR (https://github.com/callstack/react-native-paper/pull/327), we should make the `react-native-vector-icons` optional.

We can use [babel-plugin-optional-require](https://github.com/satya164/babel-plugin-optional-require) to make it happened.
