### PR TITLE
Fix TypeScript typings of nested elements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
-import { Component, ComponentType, ReactElement } from 'react'
+import { Component, ComponentType, ReactNode } from 'react'
 import { ViewStyle } from 'react-native'
 
 interface HeaderItemProps {
-  IconElement?: ReactElement<any>
+  IconElement?: ReactNode
   buttonStyle?: ViewStyle
   buttonWrapperStyle?: ViewStyle
   color?: string
@@ -15,9 +15,9 @@ interface HeaderItemProps {
 
 interface HeaderButtonsProps {
   IconComponent?: ComponentType<any>
-  OverflowIcon?: ReactElement<any>
+  OverflowIcon?: ReactNode
   cancelButtonLabel?: string
-  children: ReactElement<any>
+  children: ReactNode
   color?: string
   iconSize?: number
   left?: boolean


### PR DESCRIPTION
The current typings are not completely correct.
TypeScript emits the following error
![image](https://user-images.githubusercontent.com/3075401/39942458-d64dd30a-555f-11e8-8411-37ab52291e25.png)

The flow typings already use `ReactNode` and so should the TS typings.

