### PR TITLE
Add ripple effect to header buttons

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,12 @@
 import { Component, ComponentType, ReactNode } from 'react'
 import { TextStyle, ViewStyle } from 'react-native'
 
+interface RippleOptions {
+  pressColor: string;
+  borderless?: boolean;
+  useForeground?: boolean;
+}
+
 interface HeaderItemProps {
   IconElement?: ReactNode
   buttonStyle?: TextStyle | ViewStyle
@@ -11,6 +17,7 @@ interface HeaderItemProps {
   onPress?: () => void
   show?: string
   title: string
+  ripple?: RippleOptions
 }
 
 interface HeaderButtonsProps {
@@ -22,6 +29,7 @@ interface HeaderButtonsProps {
   iconSize?: number
   left?: boolean
   overflowButtonWrapperStyle?: ViewStyle
+  ripple?: RippleOptions
 }
 
 declare class HeaderButtons extends Component<HeaderButtonsProps> {

--- a/src/HeaderButton.js
+++ b/src/HeaderButton.js
@@ -7,22 +7,38 @@ import { StyleSheet, View } from 'react-native';
 import Touchable from 'react-native-platform-touchable';
 import type { StyleObj } from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
 
+export type RippleOptions = {
+  pressColor: string;
+  borderless?: boolean;
+  useForeground?: boolean;
+};
+
 export type HeaderButtonProps = {
   onPress: ?() => any,
   buttonWrapperStyle?: StyleObj,
   testID?: string,
+  ripple?: RippleOptions,
 };
 
 export class HeaderButton extends React.PureComponent<
   HeaderButtonProps & { ButtonElement: React.Node }
 > {
+  static defaultProps = {
+    ripple: {
+      pressColor: 'rgba(0, 0, 0, .32)',
+      borderless: false,
+      useForeground: false,
+    },
+  };
+
   render() {
-    const { ButtonElement, onPress, buttonWrapperStyle, testID } = this.props;
+    const { ButtonElement, onPress, buttonWrapperStyle, testID, ripple } = this.props;
     const RenderedComponent = !onPress ? View : Touchable;
 
     return (
       <RenderedComponent
-        background={Touchable.SelectableBackgroundBorderless()}
+        useForeground={ripple.useForeground}
+        background={Touchable.Ripple(ripple.pressColor, ripple.borderless)}
         onPress={onPress}
         hitSlop={BUTTON_HIT_SLOP}
         style={[styles.buttonContainer, buttonWrapperStyle]}

--- a/src/HeaderButtons.js
+++ b/src/HeaderButtons.js
@@ -2,7 +2,7 @@
 * @flow
 */
 import * as React from 'react';
-import { HeaderButton, type HeaderButtonProps } from './HeaderButton';
+import { HeaderButton, type HeaderButtonProps, type RippleOptions } from './HeaderButton';
 import { StyleSheet, Platform, View, Text } from 'react-native';
 import { OverflowButton, type OverflowButtonProps, IS_IOS } from './OverflowButton';
 import type { StyleObj } from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
@@ -16,6 +16,7 @@ type ItemProps = {
   IconElement?: React.Node,
   iconName?: string,
   color?: string,
+  ripple?: RippleOptions,
   iconSize?: number,
   buttonStyle?: StyleObj,
   ...$Exact<HeaderButtonProps>,
@@ -40,6 +41,7 @@ type HeaderButtonsProps = {
   IconComponent?: React.ComponentType<*>,
   iconSize?: number,
   color?: string,
+  ripple?: RippleOptions,
   overflowButtonWrapperStyle?: StyleObj,
   ...$Exact<OverflowButtonProps>,
 };
@@ -89,7 +91,7 @@ export class HeaderButtons extends React.Component<HeaderButtonsProps> {
 
       const ButtonElement = IconElement ? IconElement : this.renderVisibleButton(btn.props);
 
-      return <HeaderButton key={title} ButtonElement={ButtonElement} {...btn.props} />;
+      return <HeaderButton key={title} ButtonElement={ButtonElement} ripple={this.props.ripple} {...btn.props} />;
     });
   }
 


### PR DESCRIPTION
This would make the buttons appear consistent with `react-navigation`'s back button behavior on Android.

Here's a demo of how it looks like:
![ripple-effect](https://user-images.githubusercontent.com/2180822/41822481-391cf2ce-77be-11e8-9eae-ba5c54b19af9.gif)
