### PR TITLE
Support overloading name of "cancel"-Item in iOS-Overflowmenu

### DIFF
--- a/src/HeaderButtons.js
+++ b/src/HeaderButtons.js
@@ -47,7 +47,7 @@ export class HeaderButtons extends React.Component<HeaderButtonsProps> {
 
   render() {
     const { visibleButtons, hiddenButtons } = getVisibleAndHiddenButtons(this.props);
-    const { OverflowIcon, overflowButtonWrapperStyle, onOverflowMenuPress } = this.props;
+    const { OverflowIcon, overflowButtonWrapperStyle, onOverflowMenuPress, iosCancelTitle } = this.props;
 
     return (
       <View style={[styles.row, this.getEdgeMargin()]}>
@@ -58,6 +58,7 @@ export class HeaderButtons extends React.Component<HeaderButtonsProps> {
             OverflowIcon={OverflowIcon}
             buttonWrapperStyle={overflowButtonWrapperStyle}
             onOverflowMenuPress={onOverflowMenuPress}
+            iosCancelTitle={iosCancelTitle}
           />
         )}
       </View>

--- a/src/OverflowButton.js
+++ b/src/OverflowButton.js
@@ -19,6 +19,7 @@ export const IS_IOS = Platform.OS === 'ios';
 export type OverflowButtonProps = {
   OverflowIcon: React.Node,
   onOverflowMenuPress?: ({ hiddenButtons: Array<React.Element<*>> }) => any,
+  iosCancelTitle?: string,
 };
 
 type Props = {
@@ -80,7 +81,7 @@ export class OverflowButton extends React.Component<Props> {
 
   showPopupIos() {
     let actionTitles = this.props.hiddenButtons.map(btn => btn.props.title);
-    actionTitles.push('cancel');
+    actionTitles.push(this.props.iosCancelTitle || 'cancel');
 
     ActionSheetIOS.showActionSheetWithOptions(
       {


### PR DESCRIPTION
This is helpful f.e. in localized Apps.

Example-usage (here providing the german translation for "cancel":
         <HeaderButtons
             HeaderButtonComponent={MyHeaderButton}
             OverflowIcon={<Icon name="overflowIcon" />}
             iosCancelTitle="Abbrechen"
         ><Item ....></HeaderButtons>

if "iosCancelTitle" is not provided, it falls back to the current hard-coded "cancel"

Signed-off-by: Tim Riemenschneider <git@tim-riemenschneider.de>