### PR TITLE
Fix flow typing for renderVisibleButtons

### DIFF
--- a/src/HeaderButtons.js
+++ b/src/HeaderButtons.js
@@ -68,7 +68,7 @@ export class HeaderButtons extends React.Component<HeaderButtonsProps> {
     return this.props.left ? styles.extraEdgeMarginOnLeft : styles.extraEdgeMarginOnRight;
   }
 
-  renderVisibleButtons(visibleButtons: Array<React.Element<*>>) {
+  renderVisibleButtons(visibleButtons: Array<React.Element<*>>): Array<React.Element<*>> {
     return visibleButtons.map(btn => {
       const {
         props: { title },


### PR DESCRIPTION
When using the library, flow `0.85.0` gives the following error:

![image](https://user-images.githubusercontent.com/9068073/51936290-e4ec0980-2418-11e9-914a-472a403385ee.png)

And it's not possible to use flow typings without ignoring the library in flow config.

So, this PR fixes the error from the screenshot above.