### PR TITLE
Localize cancel button

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ static navigationOptions = {
 | OverflowIcon?: React.Element<\*>                                                                     | React element for the overflow icon                           | you need to provide this only if you need an overflow icon                                                                                                                                                                           |
 | overflowButtonWrapperStyle?: ViewStyleProp                                                           | optional styles for overflow button                           | there are some default styles set, as seen in `OverflowButton.js`                                                                                                                                                                    |
 | onOverflowMenuPress?: ({ hiddenButtons: Array<React.Element<\*>>, overflowButtonRef: ?View }) => any | function that is called when overflow menu is pressed.        | this will override the default handler                                                                                                                                                                                               |
+| overflowCancelLabel?: string  | Optional label for cancel action on iOS        | defaults to 'cancel'                                                                                                                              |
 
 `Item` accepts:
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -111,6 +111,12 @@ interface HeaderButtonsProps {
    * This will override the default handler.
    */
   onOverflowMenuPress?: (options: onOverflowMenuPressParams) => any;
+  /**
+   * Optional label to show for cancel action on iOS
+   *
+   * Defaults to 'cancel'
+   */
+  overflowCancelLabel?: string;
 }
 
 declare class HeaderButtons extends Component<HeaderButtonsProps> {

--- a/src/HeaderButtons.js
+++ b/src/HeaderButtons.js
@@ -47,7 +47,7 @@ export class HeaderButtons extends React.Component<HeaderButtonsProps> {
 
   render() {
     const { visibleButtons, hiddenButtons } = getVisibleAndHiddenButtons(this.props);
-    const { OverflowIcon, overflowButtonWrapperStyle, onOverflowMenuPress } = this.props;
+    const { OverflowIcon, overflowButtonWrapperStyle, onOverflowMenuPress, overflowCancelLabel } = this.props;
 
     return (
       <View style={[styles.row, this.getEdgeMargin()]}>
@@ -58,6 +58,7 @@ export class HeaderButtons extends React.Component<HeaderButtonsProps> {
             OverflowIcon={OverflowIcon}
             buttonWrapperStyle={overflowButtonWrapperStyle}
             onOverflowMenuPress={onOverflowMenuPress}
+            overflowCancelLabel={overflowCancelLabel}
           />
         )}
       </View>

--- a/src/OverflowButton.js
+++ b/src/OverflowButton.js
@@ -19,6 +19,7 @@ export const IS_IOS = Platform.OS === 'ios';
 export type OverflowButtonProps = {
   OverflowIcon: React.Element<*>,
   onOverflowMenuPress?: ({ hiddenButtons: Array<React.Element<*>> }) => any,
+  overflowCancelLabel?: string
 };
 
 type Props = {
@@ -80,7 +81,7 @@ export class OverflowButton extends React.Component<Props> {
 
   showPopupIos() {
     let actionTitles = this.props.hiddenButtons.map(btn => btn.props.title);
-    actionTitles.push('cancel');
+    actionTitles.push(this.props.overflowCancelLabel || 'cancel');
 
     ActionSheetIOS.showActionSheetWithOptions(
       {


### PR DESCRIPTION
On iOS the overflow button will show an ActionSheet where the last option allows closing the sheet without performing any action.

Currently the label of the last action is always 'cancel'. Sometimes you might want a different label, e.g. something localized to a different language.

This PR adds a new `overflowCancelLabel` prop, that allows override the default label.