### PR TITLE
Make the margin of HeaderButtons right on web.

### DIFF
--- a/src/HeaderButtons.js
+++ b/src/HeaderButtons.js
@@ -129,6 +129,9 @@ const styles = StyleSheet.create({
       ios: {
         marginLeft: 4,
       },
+      web: {
+        marginLeft: 4,
+      },
     }),
   },
   extraEdgeMarginOnRight: {
@@ -137,6 +140,9 @@ const styles = StyleSheet.create({
         marginRight: 4,
       },
       ios: {
+        marginRight: 5,
+      },
+      web: {
         marginRight: 5,
       },
     }),
@@ -152,6 +158,10 @@ const styles = StyleSheet.create({
         fontSize: 17,
         marginHorizontal: 10,
       },
+      web: {
+        fontSize: 17,
+        marginHorizontal: 10,
+      },
     }),
   },
   button: {
@@ -160,6 +170,9 @@ const styles = StyleSheet.create({
         marginHorizontal: 11,
       },
       ios: {
+        marginHorizontal: 11,
+      },
+      web: {
         marginHorizontal: 11,
       },
     }),


### PR DESCRIPTION
I use `react-navigation-header-buttons` on both ios, android and also web by [react-native-web](https://github.com/necolas/react-native-web).
It is pretty cool that `react-navigation-header-buttons` works almost perfect on our web.

But only the margins of `HeaderButtons` looks weird
<img width="283" alt="螢幕快照 2019-03-28 上午3 01 26" src="https://user-images.githubusercontent.com/1034290/55105196-f135cf80-5106-11e9-9339-1f6ff4950d4f.png">

I notice that the original styles didn't consider the situation on web.
```
const styles = StyleSheet.create({
  row: { flexDirection: 'row' },
  extraEdgeMarginOnLeft: {
    ...Platform.select({
      android: {
        marginLeft: 5,
      },
      ios: {
        marginLeft: 4,
      },
    }),
  },
  extraEdgeMarginOnRight: {
    ...Platform.select({
      android: {
        marginRight: 4,
      },
      ios: {
        marginRight: 5,
      },
    }),
  },
  text: {
    ...Platform.select({
      android: {
        fontFamily: 'sans-serif-medium',
        fontSize: 14,
        marginHorizontal: 11,
      },
      ios: {
        fontSize: 17,
        marginHorizontal: 10,
      },
    }),
  },
  button: {
    ...Platform.select({
      android: {
        marginHorizontal: 11,
      },
      ios: {
        marginHorizontal: 11,
      },
    }),
  },
});
```

So I add the web support and it looks perfect
<img width="284" alt="螢幕快照 2019-03-28 上午2 58 53" src="https://user-images.githubusercontent.com/1034290/55105378-58538400-5107-11e9-9ec1-d1bcff6b7d09.png">

thanks.