### PR TITLE
Make the cancel button in iOS ActionSheets customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ static navigationOptions = {
 | OverflowIcon?: React.Element<\*>                                                                     | React element for the overflow icon                           | you need to provide this only if you need an overflow icon                                                                                                                                                                                 |
 | overflowButtonWrapperStyle?: ViewStyleProp                                                           | optional styles for overflow button                           | there are some default styles set, as seen in `OverflowButton.js`                                                                                                                                                                          |
 | onOverflowMenuPress?: ({ hiddenButtons: Array<React.Element<\*>>, overflowButtonRef: ?View }) => any | function that is called when overflow menu is pressed.        | This will override the default handler. Use this prop if you want to customize your overflow button behavior - I will likely not merge PRs that add props for the overflow menu since I prefer these customizations to happen in userland. |
+| overflowCancelButtonTitle?: string                                                                   | title for the cancel button shown in overflow menus on iOS    | This will override the default title 'cancel'.
 
 `Item` accepts:
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -75,7 +75,6 @@ interface HeaderItemProps extends CommonHeaderButtonProps {
 }
 
 export interface onOverflowMenuPressParams {
-  overflowCancelButtonTitle: string,
   hiddenButtons: Array<ReactNode>,
   overflowButtonRef?: View,
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -75,6 +75,7 @@ interface HeaderItemProps extends CommonHeaderButtonProps {
 }
 
 export interface onOverflowMenuPressParams {
+  overflowCancelButtonTitle: string,
   hiddenButtons: Array<ReactNode>,
   overflowButtonRef?: View,
 }
@@ -111,6 +112,12 @@ interface HeaderButtonsProps {
    * This will override the default handler.
    */
   onOverflowMenuPress?: (options: onOverflowMenuPressParams) => any;
+  /**
+   * Title for the cancel button shown in overflow menus on iOS.
+   *
+   * This will override the default title 'cancel'.
+   */
+  overflowCancelButtonTitle?: string;
 }
 
 declare class HeaderButtons extends Component<HeaderButtonsProps> {

--- a/src/HeaderButtons.js
+++ b/src/HeaderButtons.js
@@ -33,6 +33,7 @@ type HeaderButtonsProps = {
   children: React.Node,
   left: boolean,
   overflowButtonWrapperStyle?: ViewStyleProp,
+  overflowCancelButtonTitle?: string,
   HeaderButtonComponent: React.ComponentType<*>,
   ...$Exact<OverflowButtonProps>,
 };
@@ -47,7 +48,7 @@ export class HeaderButtons extends React.Component<HeaderButtonsProps> {
 
   render() {
     const { visibleButtons, hiddenButtons } = getVisibleAndHiddenButtons(this.props);
-    const { OverflowIcon, overflowButtonWrapperStyle, onOverflowMenuPress } = this.props;
+    const { OverflowIcon, overflowButtonWrapperStyle, onOverflowMenuPress, overflowCancelButtonTitle } = this.props;
 
     return (
       <View style={[styles.row, this.getEdgeMargin()]}>
@@ -58,6 +59,7 @@ export class HeaderButtons extends React.Component<HeaderButtonsProps> {
             OverflowIcon={OverflowIcon}
             buttonWrapperStyle={overflowButtonWrapperStyle}
             onOverflowMenuPress={onOverflowMenuPress}
+            overflowCancelButtonTitle={overflowCancelButtonTitle}
           />
         )}
       </View>

--- a/src/OverflowButton.js
+++ b/src/OverflowButton.js
@@ -17,6 +17,7 @@ export const OVERFLOW_BUTTON_TEST_ID = 'headerOverflowButton';
 export const IS_IOS = Platform.OS === 'ios';
 
 export type OverflowButtonProps = {
+  overflowCancelButtonTitle?: string,
   OverflowIcon: React.Element<*>,
   onOverflowMenuPress?: ({ hiddenButtons: Array<React.Element<*>> }) => any,
 };
@@ -80,7 +81,7 @@ export class OverflowButton extends React.Component<Props> {
 
   showPopupIos() {
     let actionTitles = this.props.hiddenButtons.map(btn => btn.props.title);
-    actionTitles.push('cancel');
+    actionTitles.push(this.props.overflowCancelButtonTitle || 'cancel');
 
     ActionSheetIOS.showActionSheetWithOptions(
       {


### PR DESCRIPTION
This pull request basically adds the option to customize the title of the cancel button in overflow menus on iOS.
On iOS, an ActionSheet has been shown with a cancel button having a hard coded 'cancel' title until now.
The new optional 'overflowCancelButtonTitle' property of the HeaderButtons component allows to define a custom title for this button. If it is not set, the default 'cancel' title will still be used.