### PR TITLE
Add missing exported HiddenItem class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -124,4 +124,4 @@ declare class HeaderButtons extends Component<HeaderButtonsProps> {
 
 declare class Item extends Component<HeaderItemProps> {}
 
-declare class HiddenItem extends Item {}
+declare class HiddenItem extends Component<HeaderItemProps> {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -123,3 +123,5 @@ declare class HeaderButtons extends Component<HeaderButtonsProps> {
 }
 
 declare class Item extends Component<HeaderItemProps> {}
+
+declare class HiddenItem extends Item {}


### PR DESCRIPTION
`HiddenItem` class, exported by `index.js`, is missing TypeScript types in `index.d.ts`.