### PR TITLE
Add a keyExtractor api to HeaderButtons component.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ static navigationOptions = {
 | overflowButtonWrapperStyle?: ViewStyleProp                                                           | optional styles for overflow button                           | there are some default styles set, as seen in `OverflowButton.js`                                                                                                                                                                    |
 | onOverflowMenuPress?: ({ hiddenButtons: Array<React.Element<any>>, overflowButtonRef: View }) => any | function that is called when overflow menu is pressed.        | This will override the default handler. Note the default handler offers (limited) customization. See more below.                                                                                                                     |
 | overflowButtonTestID?: string                                                                        | testID to locate the overflow button in e2e tests             | the default is available under `import { OVERFLOW_BUTTON_TEST_ID } from 'react-navigation-header-buttons/e2e'`                                                                                                                       |
+| keyExtractor?: (item: HeaderButtonProps, index: number) => string | function that is called to determine the key of the children of HeaderButtons. | The default function uses the title prop as the key. `(item) => item.title,`
 
 `Item` accepts:
 

--- a/src/HeaderButtons.js
+++ b/src/HeaderButtons.js
@@ -16,6 +16,7 @@ type HeaderButtonsProps = {
   left: boolean,
   overflowButtonWrapperStyle?: ViewStyleProp,
   overflowButtonTestID?: string,
+  keyExtractor?: (item: any, index: number) => string,
   HeaderButtonComponent: React.ComponentType<any>,
   ...$Exact<OverflowButtonProps>,
 };
@@ -24,6 +25,7 @@ export class HeaderButtons extends React.Component<HeaderButtonsProps> {
   static Item = Item;
   static defaultProps = {
     left: false,
+    keyExtractor: (btn) => btn.title,
     HeaderButtonComponent: HeaderButton,
     OverflowIcon: <View />,
   };
@@ -58,15 +60,12 @@ export class HeaderButtons extends React.Component<HeaderButtonsProps> {
   }
 
   renderVisibleButtons(visibleButtons: Array<React.Element<any>>): Array<React.Element<any>> {
-    return visibleButtons.map(btn => {
-      const {
-        props: { title },
-      } = btn;
-
+    const { keyExtractor } = this.props;
+    return visibleButtons.map((btn, index) => {
       const RenderedHeaderButton = this.props.HeaderButtonComponent;
 
       return (
-        <RenderedHeaderButton key={title} {...btn.props} getButtonElement={renderVisibleButton} />
+        <RenderedHeaderButton key={keyExtractor(btn.props, index)} {...btn.props} getButtonElement={renderVisibleButton} />
       );
     });
   }
@@ -104,8 +103,8 @@ function renderVisibleButton(visibleButtonProps: VisibleButtonProps): React.Elem
       style={[styles.button, buttonStyle]}
     />
   ) : (
-    <Text style={[styles.text, { color }, buttonStyle]}>{textTransformer(title)}</Text>
-  );
+      <Text style={[styles.text, { color }, buttonStyle]}>{textTransformer(title)}</Text>
+    );
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
We ran into an issue recently where we began to wrap `HeaderButton` with simple wrapper that would add the needed props etc. However we ran into key warnings because `HeaderButtons` would map over the children and use the title prop, and our title prop did not exist on that component but the one it wrapped.

See this code sandbox for a simple illustration of the problem. https://codesandbox.io/s/cocky-villani-v6l31. 

I thought a simple way to address this issue would be to add a keyExtractor prop to `HeaderButtons`, similar to other list components, that would easily allow us to customize what was used as the key.

This implementation also has a default keyExtractor function that will use the title as the key so it should be backwards compatible. 

I'd be happy to address any concerns or feedback. 
