### PR TITLE
Do not render OverflowMenu without child elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ This limitation may look weird but it should not really limit you in any way: if
 The limitation exists because we need to be able to transform declarative React elements into imperative calls (`ActionSheetIOS.showActionSheetWithOptions` / `UIManager.showPopupMenu`).
 If this is a problem for you for some reason, please raise an issue and we'll see what can be done about it.
 
-If `OverflowMenu` contains no child elements, nothing will be rendered at all. (No `OverflowIcon`, no wrapper.)
+If `OverflowMenu` contains no valid child elements, nothing will be rendered at all. (No `OverflowIcon`, no wrapper.)
 
 <details><summary>examples</summary>
 <p>

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ This limitation may look weird but it should not really limit you in any way: if
 The limitation exists because we need to be able to transform declarative React elements into imperative calls (`ActionSheetIOS.showActionSheetWithOptions` / `UIManager.showPopupMenu`).
 If this is a problem for you for some reason, please raise an issue and we'll see what can be done about it.
 
+If `OverflowMenu` contains no child elements, nothing will be rendered at all. (No `OverflowIcon`, no wrapper.)
+
 <details><summary>examples</summary>
 <p>
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -105,7 +105,7 @@ export interface OnOverflowMenuPressParams {
 }
 
 declare class OverflowMenu extends Component<{
-  children?: ReactChild | Array<ReactNode>;
+  children: ReactChild | Array<ReactNode>;
   onPress?: (OnOverflowMenuPressParams) => any;
   OverflowIcon: ReactNode;
   style?: StyleProp<ViewStyle>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -105,7 +105,7 @@ export interface OnOverflowMenuPressParams {
 }
 
 declare class OverflowMenu extends Component<{
-  children: ReactChild | Array<ReactNode>;
+  children?: ReactChild | Array<ReactNode>;
   onPress?: (OnOverflowMenuPressParams) => any;
   OverflowIcon: ReactNode;
   style?: StyleProp<ViewStyle>;

--- a/src/overflowMenu/OverflowMenu.js
+++ b/src/overflowMenu/OverflowMenu.js
@@ -47,7 +47,7 @@ export const OverflowMenu = ({
     });
   }, [children, onPress, toggleMenu]);
 
-  if (!children) {
+  if (!children || Array.isArray(children) && children.every(it => !it)) {
     return null;
   }
 

--- a/src/overflowMenu/OverflowMenu.js
+++ b/src/overflowMenu/OverflowMenu.js
@@ -14,7 +14,7 @@ import { OVERFLOW_BUTTON_TEST_ID } from '../e2e';
 import { ButtonsWrapper } from '../ButtonsWrapper';
 
 export type OverflowMenuProps = {|
-  children: React.Node,
+  children?: React.Node,
   OverflowIcon: React.Element<any>,
   style?: ViewStyleProp,
   testID: string,
@@ -46,6 +46,10 @@ export const OverflowMenu = ({
       _private_toggleMenu: toggleMenu,
     });
   }, [children, onPress, toggleMenu]);
+
+  if (!children) {
+    return null;
+  }
 
   return (
     <ButtonsWrapper left={left}>

--- a/src/overflowMenu/OverflowMenu.js
+++ b/src/overflowMenu/OverflowMenu.js
@@ -37,6 +37,10 @@ export const OverflowMenu = ({
   const renderButtonElement = React.useCallback(() => OverflowIcon, [OverflowIcon]);
 
   const usedOnPress = React.useCallback(() => {
+    if (!children) {
+      return;
+    }
+
     const titlesAndOnPresses =
       onPress === overflowMenuPressHandlerDropdownMenu ? [] : extractOverflowButtonData(children);
     onPress({

--- a/src/overflowMenu/OverflowMenu.js
+++ b/src/overflowMenu/OverflowMenu.js
@@ -51,7 +51,7 @@ export const OverflowMenu = ({
     });
   }, [children, onPress, toggleMenu]);
 
-  if (!children || Array.isArray(children) && children.every(it => !it)) {
+  if (!children || (Array.isArray(children) && children.every((it) => !it))) {
     return null;
   }
 

--- a/src/overflowMenu/OverflowMenu.js
+++ b/src/overflowMenu/OverflowMenu.js
@@ -14,7 +14,7 @@ import { OVERFLOW_BUTTON_TEST_ID } from '../e2e';
 import { ButtonsWrapper } from '../ButtonsWrapper';
 
 export type OverflowMenuProps = {|
-  children?: React.Node,
+  children: React.Node,
   OverflowIcon: React.Element<any>,
   style?: ViewStyleProp,
   testID: string,
@@ -37,10 +37,6 @@ export const OverflowMenu = ({
   const renderButtonElement = React.useCallback(() => OverflowIcon, [OverflowIcon]);
 
   const usedOnPress = React.useCallback(() => {
-    if (!children) {
-      return;
-    }
-
     const titlesAndOnPresses =
       onPress === overflowMenuPressHandlerDropdownMenu ? [] : extractOverflowButtonData(children);
     onPress({
@@ -51,7 +47,8 @@ export const OverflowMenu = ({
     });
   }, [children, onPress, toggleMenu]);
 
-  if (!children || (Array.isArray(children) && children.every((it) => !it))) {
+  const validChildren = React.Children.toArray(children).filter(React.isValidElement)
+  if (validChildren.length === 0) {
     return null;
   }
 

--- a/src/overflowMenu/OverflowMenu.js
+++ b/src/overflowMenu/OverflowMenu.js
@@ -47,7 +47,7 @@ export const OverflowMenu = ({
     });
   }, [children, onPress, toggleMenu]);
 
-  const validChildren = React.Children.toArray(children).filter(React.isValidElement)
+  const validChildren = React.Children.toArray(children).filter(React.isValidElement);
   if (validChildren.length === 0) {
     return null;
   }

--- a/src/overflowMenu/__tests__/OverflowMenu.test.js
+++ b/src/overflowMenu/__tests__/OverflowMenu.test.js
@@ -100,38 +100,30 @@ describe('overflowMenu', () => {
     }
   );
 
-  it('should not render overflow button when no child element is specified', () => {
-    const onPress = jest.fn();
+  describe('should not render overflow button when', () => {
+    it('only single falsy child is specified', () => {
+      const onPress = jest.fn();
 
-    const { queryByA11yLabel } = render(
-      <OverflowMenu OverflowIcon={<Text>+</Text>} onPress={onPress} />
-    );
+      const { toJSON } = render(
+        <OverflowMenu OverflowIcon={<Text>+</Text>} onPress={onPress}>
+          {null}
+        </OverflowMenu>
+      );
 
-    expect(queryByA11yLabel('More options')).toBeNull();
-  });
+      expect(toJSON()).toBeNull();
+    });
 
-  it('should not render overflow button when only single falsy child is specified', () => {
-    const onPress = jest.fn();
+    it('only falsy children are specified', () => {
+      const onPress = jest.fn();
 
-    const { queryByA11yLabel } = render(
-      <OverflowMenu OverflowIcon={<Text>+</Text>} onPress={onPress}>
-        {null}
-      </OverflowMenu>
-    );
+      const { toJSON } = render(
+        <OverflowMenu OverflowIcon={<Text>+</Text>} onPress={onPress}>
+          {false}
+          {null}
+        </OverflowMenu>
+      );
 
-    expect(queryByA11yLabel('More options')).toBeNull();
-  });
-
-  it('should not render overflow button when only falsy children are specified', () => {
-    const onPress = jest.fn();
-
-    const { queryByA11yLabel } = render(
-      <OverflowMenu OverflowIcon={<Text>+</Text>} onPress={onPress}>
-        {false}
-        {null}
-      </OverflowMenu>
-    );
-
-    expect(queryByA11yLabel('More options')).toBeNull();
+      expect(toJSON()).toBeNull();
+    });
   });
 });

--- a/src/overflowMenu/__tests__/OverflowMenu.test.js
+++ b/src/overflowMenu/__tests__/OverflowMenu.test.js
@@ -100,11 +100,36 @@ describe('overflowMenu', () => {
     }
   );
 
-  it('should not render overflow button when no item is specified', () => {
+  it('should not render overflow button when no child element is specified', () => {
     const onPress = jest.fn();
 
     const { queryByA11yLabel } = render(
       <OverflowMenu OverflowIcon={<Text>+</Text>} onPress={onPress} />
+    );
+
+    expect(queryByA11yLabel('More options')).toBeNull();
+  });
+
+  it('should not render overflow button when only single falsy child is specified', () => {
+    const onPress = jest.fn();
+
+    const { queryByA11yLabel } = render(
+      <OverflowMenu OverflowIcon={<Text>+</Text>} onPress={onPress}>
+        {null}
+      </OverflowMenu>
+    );
+
+    expect(queryByA11yLabel('More options')).toBeNull();
+  });
+
+  it('should not render overflow button when only falsy children are specified', () => {
+    const onPress = jest.fn();
+
+    const { queryByA11yLabel } = render(
+      <OverflowMenu OverflowIcon={<Text>+</Text>} onPress={onPress}>
+        {false}
+        {null}
+      </OverflowMenu>
     );
 
     expect(queryByA11yLabel('More options')).toBeNull();

--- a/src/overflowMenu/__tests__/OverflowMenu.test.js
+++ b/src/overflowMenu/__tests__/OverflowMenu.test.js
@@ -99,4 +99,14 @@ describe('overflowMenu', () => {
       });
     }
   );
+
+  it('should not render overflow button when no item is specified', () => {
+    const onPress = jest.fn();
+
+    const { queryByA11yLabel } = render(
+      <OverflowMenu OverflowIcon={<Text>+</Text>} onPress={onPress} />
+    );
+
+    expect(queryByA11yLabel('More options')).toBeNull();
+  });
 });


### PR DESCRIPTION
Version 3 of this library do not render overflow button when no hidden items were specified. This introduces same behaviour to v4.