### PR TITLE
Types - Adding testID property to HiddenItem.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -87,6 +87,7 @@ declare class HiddenItem extends Component<{
   onPress?: () => any;
   style?: StyleProp<ViewStyle>;
   titleStyle?: StyleProp<TextStyle>;
+  testID?: string;
   destructive?: boolean;
 }> {}
 


### PR DESCRIPTION
The `HiddenItem` button type lacks the `testID` property in the type definition. The actual property is already being used in the JavaScript code, so it's only missing a type definition.