### PR TITLE
fix dropdown so it works in RN and expo

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -19,7 +19,7 @@ import { NavigationContainer } from '@react-navigation/native';
 import { OverflowMenuProvider } from 'react-navigation-header-buttons';
 // just for custom overflow menu onPress action
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
-
+import { StatusBar } from 'expo-status-bar';
 import { createStackNavigator } from '@react-navigation/stack';
 // import { createNativeStackNavigator as createStackNavigator } from 'react-native-screens/native-stack';
 
@@ -41,11 +41,16 @@ const Stack = createStackNavigator();
 const Body = () => {
   // console.warn('render');
   return (
-    <Stack.Navigator>
-      {Object.keys(screens).map((screenName) => {
-        return <Stack.Screen name={screenName} key={screenName} component={screens[screenName]} />;
-      })}
-    </Stack.Navigator>
+    <>
+      <StatusBar barStyle="light-content" backgroundColor="lightgreen" />
+      <Stack.Navigator>
+        {Object.keys(screens).map((screenName) => {
+          return (
+            <Stack.Screen name={screenName} key={screenName} component={screens[screenName]} />
+          );
+        })}
+      </Stack.Navigator>
+    </>
   );
 };
 

--- a/example/package.json
+++ b/example/package.json
@@ -18,6 +18,7 @@
     "@react-navigation/native": "^5.1.1",
     "@react-navigation/stack": "^5.2.3",
     "expo": "^37.0.0",
+    "expo-status-bar": "^1.0.2",
     "react": "16.9.0",
     "react-dom": "16.9.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.0.tar.gz",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2514,6 +2514,11 @@ expo-sqlite@~8.1.0:
     "@types/websql" "^0.0.27"
     lodash "^4.17.15"
 
+expo-status-bar@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/expo-status-bar/-/expo-status-bar-1.0.2.tgz#2441a77c56be31597898337b0d086981f2adefd8"
+  integrity sha512-5313u744GcLzCadxIPXyTkYw77++UXv1dXCuhYDxDbtsEf93iMra7WSvzyE8a7mRQLIIPRuGnBOdrL/V1C7EOQ==
+
 expo-web-browser@~8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/expo-web-browser/-/expo-web-browser-8.1.0.tgz#1b4ca25e4dd600fac9ad16e32d81be47778c2667"

--- a/src/overflowMenu/OverflowMenuContext.js
+++ b/src/overflowMenu/OverflowMenuContext.js
@@ -41,7 +41,6 @@ export const OverflowMenuProvider = ({ children }: Props) => {
     if (params) {
       const { x, y } = params;
       const heightApprox = getSpaceAboveMenu();
-      console.warn(heightApprox, y);
       const extraDelta = Platform.select({
         android: heightApprox,
         default: OVERFLOW_TOP,

--- a/src/overflowMenu/OverflowMenuContext.js
+++ b/src/overflowMenu/OverflowMenuContext.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { Dimensions, Platform } from 'react-native';
 import { Menu } from './vendor/Menu';
+import { getSpaceAboveMenu } from './statusBarUtils';
 
 export type ToggleMenuParam = ?{|
   elements: React.ChildrenArray<any>,
@@ -12,8 +13,7 @@ export type ToggleMenuParam = ?{|
 export const OVERFLOW_TOP = 15;
 
 const warn = () => {
-  // this is here just to satisfy Flow, the noop value will be replaced
-  // by OverflowMenuProvider rendered in app root
+  // the noop value will be replaced by OverflowMenuProvider rendered in app root
   console.warn(
     'It seems like you tried to open the overflow menu using the overflowMenuPressHandlerDropdownMenu' +
       ' - which is the default handler on android - but you forgot to wrap your root component in <OverflowMenuProvider />.' +
@@ -40,9 +40,10 @@ export const OverflowMenuProvider = ({ children }: Props) => {
     setElements(params?.elements || []);
     if (params) {
       const { x, y } = params;
-      const approxAndroidStatusBarHeight = 25;
+      const heightApprox = getSpaceAboveMenu();
+      console.warn(heightApprox, y);
       const extraDelta = Platform.select({
-        android: OVERFLOW_TOP + approxAndroidStatusBarHeight,
+        android: heightApprox,
         default: OVERFLOW_TOP,
       });
       setPosition({ x, y: y + extraDelta });

--- a/src/overflowMenu/statusBarUtils.expo.js
+++ b/src/overflowMenu/statusBarUtils.expo.js
@@ -1,6 +1,7 @@
 import { StatusBar } from 'react-native';
 
 export const getSpaceAboveMenu = () => {
-  // approximation
+  // approximation, expo draws views right from below the display edge
+  // which is a different behavior from vanilla RN
   return StatusBar.currentHeight + 3;
 };

--- a/src/overflowMenu/statusBarUtils.expo.js
+++ b/src/overflowMenu/statusBarUtils.expo.js
@@ -1,0 +1,6 @@
+import { StatusBar } from 'react-native';
+
+export const getSpaceAboveMenu = () => {
+  // approximation
+  return StatusBar.currentHeight + 3;
+};

--- a/src/overflowMenu/statusBarUtils.js
+++ b/src/overflowMenu/statusBarUtils.js
@@ -1,5 +1,3 @@
-import { StatusBar } from 'react-native';
-
 export const getSpaceAboveMenu = () => {
-  return StatusBar.currentHeight;
+  return 0;
 };

--- a/src/overflowMenu/statusBarUtils.js
+++ b/src/overflowMenu/statusBarUtils.js
@@ -1,0 +1,5 @@
+import { StatusBar } from 'react-native';
+
+export const getSpaceAboveMenu = () => {
+  return StatusBar.currentHeight;
+};


### PR DESCRIPTION
this makes sure that `overflowMenuPressHandlerDropdownMenu` displays menu in the right position in both expo and vanilla RN apps