### PR TITLE
Option to make textTransform optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Renders text, or icon, and has an `onPress` handler. Take a look at the example 
 | prop and type               | description                                                                 | note                          |
 | --------------------------- | --------------------------------------------------------------------------- | ----------------------------- |
 | title: string               | title for the button, required                                              |                               |
+| transformText: boolean      | if text should transform (iOS Captialized, Android UPPERCASE), default true |                               |
 | onPress: ?() => any         | function to call on press                                                   |                               |
 | iconName?: string           | icon name, used together with the `IconComponent` prop                      |                               |
 | style?: ViewStyleProp       | style to apply to the touchable element that wraps the button               |                               |

--- a/src/HeaderButton.js
+++ b/src/HeaderButton.js
@@ -16,6 +16,7 @@ export type VisibleButtonProps = {|
   iconName?: string,
   title: string,
   buttonStyle?: ViewStyleProp,
+  transformText?: Boolean,
 |};
 
 // from <Item />
@@ -45,6 +46,7 @@ export function HeaderButton(props: HeaderButtonProps) {
     background,
     iconName,
     title,
+    transformText,
     buttonStyle,
     IconComponent,
     iconSize,
@@ -55,6 +57,7 @@ export function HeaderButton(props: HeaderButtonProps) {
   const ButtonElement = renderButtonElement({
     iconName,
     title,
+    transformText,
     buttonStyle,
     IconComponent,
     iconSize,

--- a/src/HeaderItems.js
+++ b/src/HeaderItems.js
@@ -35,7 +35,7 @@ export function Item(props: ItemProps) {
 }
 
 export function renderVisibleButton(visibleButtonProps: VisibleButtonProps): React.Element<any> {
-  const { IconComponent, iconSize, color, iconName, title, buttonStyle } = visibleButtonProps;
+  const { IconComponent, iconSize, color, iconName, title, buttonStyle, transformText=true } = visibleButtonProps;
 
   return IconComponent && iconName ? (
     <IconComponent
@@ -45,7 +45,7 @@ export function renderVisibleButton(visibleButtonProps: VisibleButtonProps): Rea
       style={StyleSheet.compose(styles.button, buttonStyle)}
     />
   ) : (
-    <Text style={[styles.text, { color }, buttonStyle]}>{textTransformer(title)}</Text>
+    <Text style={[styles.text, { color }, buttonStyle]}>{transformText ? textTransformer(title) : title}</Text>
   );
 }
 

--- a/src/HeaderItems.js
+++ b/src/HeaderItems.js
@@ -35,7 +35,15 @@ export function Item(props: ItemProps) {
 }
 
 export function renderVisibleButton(visibleButtonProps: VisibleButtonProps): React.Element<any> {
-  const { IconComponent, iconSize, color, iconName, title, buttonStyle, transformText=true } = visibleButtonProps;
+  const {
+    IconComponent,
+    iconSize,
+    color,
+    iconName,
+    title,
+    buttonStyle,
+    transformText = true,
+  } = visibleButtonProps;
 
   return IconComponent && iconName ? (
     <IconComponent
@@ -45,7 +53,9 @@ export function renderVisibleButton(visibleButtonProps: VisibleButtonProps): Rea
       style={StyleSheet.compose(styles.button, buttonStyle)}
     />
   ) : (
-    <Text style={[styles.text, { color }, buttonStyle]}>{transformText ? textTransformer(title) : title}</Text>
+    <Text style={[styles.text, { color }, buttonStyle]}>
+      {transformText ? textTransformer(title) : title}
+    </Text>
   );
 }
 


### PR DESCRIPTION
Adds an option to make the text transformation of the title optional. Should not break anything because defaults to true. 

My use case: In my designs the buttons should be "Save" in both Android and iOS, but that was not possible until now because in Android it always displayed "SAVE" in capitalized letters.