### PR TITLE
Typescript missing parameter fix

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -106,7 +106,7 @@ export interface OnOverflowMenuPressParams {
 
 declare class OverflowMenu extends Component<{
   children: ReactChild | Array<ReactNode>;
-  onPress?: (OnOverflowMenuPressParams) => any;
+  onPress?: (parameter: OnOverflowMenuPressParams) => any;
   OverflowIcon: ReactNode;
   style?: StyleProp<ViewStyle>;
   testID?: string;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "jest",
     "lint": "eslint ./src",
+    "typescript": "tsc --noEmit --strict index.d.ts",
     "flow": "flow check"
   },
   "files": [


### PR DESCRIPTION
Fixes the issue https://github.com/vonovak/react-navigation-header-buttons/issues/113 by adding the missing parameter. This pull request also adds a yarn script to check for errors in the definition file.

Running this script will always throw 2 errors: one for missing react types and one for missing react-native types. Installing @types/react and @types/react-native generated even more errors so I gave up on this idea. Nonetheless, this script is useful to check for other errors in the definition file. 

