### PR TITLE
fix: extends TouchableWithoutFeedback in interface HeaderItemProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
-import { Component, ComponentType, ReactNode, ReactChild } from 'react';
-import { TextStyle, ViewStyle, View, StyleProp } from 'react-native';
+import { Component, ComponentProps, ComponentType, ReactNode, ReactChild } from 'react';
+import { TextStyle, TouchableWithoutFeedback, ViewStyle, View, StyleProp } from 'react-native';
 
 export interface CommonHeaderButtonProps {
   /**
@@ -73,7 +73,9 @@ export interface HeaderButtonsProps {
 declare class HeaderButtons extends Component<HeaderButtonsProps> {}
 
 // From HeaderButtons.js as ItemProps
-export interface HeaderItemProps extends HeaderButtonProps {}
+export interface HeaderItemProps
+  extends HeaderButtonProps,
+    React.ComponentProps<typeof TouchableWithoutFeedback> {}
 
 declare class Item extends Component<HeaderItemProps> {}
 


### PR DESCRIPTION
# Why
I investigated issue #125 and accessibility props seem to be working fine. However, the component Item doesn't expect them because the type `HeaderItemProps` does not extend the base `TouchableWithoutFeedback`.

It shows up in autocomplete now
![Screenshot from 2021-10-27 15-29-37](https://user-images.githubusercontent.com/6487206/139125329-f7aa981b-a71b-48b9-bd2e-e619a74a88a6.png)

