### PR TITLE
Fix removeEventListener warning in rn0.65

### DIFF
--- a/src/overflowMenu/vendor/Menu.js
+++ b/src/overflowMenu/vendor/Menu.js
@@ -240,15 +240,15 @@ export class Menu extends React.Component<Props, State> {
   };
 
   attachListeners = () => {
-    this.backPressListner = BackHandler.addEventListener('hardwareBackPress', this.handleDismiss);
-    this.dimenstionChangeListner = Dimensions.addEventListener('change', this.handleDismiss);
+    this.backPressListener = BackHandler.addEventListener('hardwareBackPress', this.handleDismiss);
+    this.dimenstionChangeListener = Dimensions.addEventListener('change', this.handleDismiss);
 
     this.isBrowser() && document.addEventListener('keyup', this.handleKeypress);
   };
 
   removeListeners = () => {
-    this.backPressListner.remove();
-    this.dimenstionChangeListner.remove();
+    this?.backPressListener?.remove();
+    this?.dimenstionChangeListener?.remove();
 
     this.isBrowser() && document.removeEventListener('keyup', this.handleKeypress);
   };

--- a/src/overflowMenu/vendor/Menu.js
+++ b/src/overflowMenu/vendor/Menu.js
@@ -240,15 +240,15 @@ export class Menu extends React.Component<Props, State> {
   };
 
   attachListeners = () => {
-    BackHandler.addEventListener('hardwareBackPress', this.handleDismiss);
-    Dimensions.addEventListener('change', this.handleDismiss);
+    this.backPressListner = BackHandler.addEventListener('hardwareBackPress', this.handleDismiss);
+    this.dimenstionChangeListner = Dimensions.addEventListener('change', this.handleDismiss);
 
     this.isBrowser() && document.addEventListener('keyup', this.handleKeypress);
   };
 
   removeListeners = () => {
-    BackHandler.removeEventListener('hardwareBackPress', this.handleDismiss);
-    Dimensions.removeEventListener('change', this.handleDismiss);
+    this.backPressListner.remove();
+    this.dimenstionChangeListner.remove();
 
     this.isBrowser() && document.removeEventListener('keyup', this.handleKeypress);
   };

--- a/src/overflowMenu/vendor/Menu.js
+++ b/src/overflowMenu/vendor/Menu.js
@@ -241,14 +241,14 @@ export class Menu extends React.Component<Props, State> {
 
   attachListeners = () => {
     this.backPressListener = BackHandler.addEventListener('hardwareBackPress', this.handleDismiss);
-    this.dimenstionChangeListener = Dimensions.addEventListener('change', this.handleDismiss);
+    this.dimensionChangeListener = Dimensions.addEventListener('change', this.handleDismiss);
 
     this.isBrowser() && document.addEventListener('keyup', this.handleKeypress);
   };
 
   removeListeners = () => {
     this?.backPressListener?.remove();
-    this?.dimenstionChangeListener?.remove();
+    this?.dimensionChangeListener?.remove();
 
     this.isBrowser() && document.removeEventListener('keyup', this.handleKeypress);
   };


### PR DESCRIPTION
 removeEventListener is deprecated in React-native >= 0.65 and will throw warnings