### PR TITLE
fix: typing on IconComponent

### DIFF
--- a/src/HeaderButton.tsx
+++ b/src/HeaderButton.tsx
@@ -18,7 +18,7 @@ export type VisibleButtonProps = {
   IconComponent?: React.ComponentType<{
     name: any; // TODO generify to support icon names
     style?: any;
-    color?: ColorValue;
+    color?: ColorValue | number;
     size?: number;
   }>;
   iconName?: string;

--- a/src/HeaderButton.tsx
+++ b/src/HeaderButton.tsx
@@ -15,12 +15,19 @@ import type { ComponentProps, ReactNode } from 'react';
 export type VisibleButtonProps = {
   title: string;
 
-  IconComponent?: React.ComponentType<{
-    name: any; // TODO generify to support icon names
-    style?: any;
-    color?: ColorValue | number;
-    size?: number;
-  }>;
+  IconComponent?:
+    | React.ComponentType<{
+        name: any; // TODO generify to support icon names
+        style?: any;
+        size?: number;
+        color?: ColorValue;
+      }>
+    | React.ComponentType<{
+        name: any; // TODO generify to support icon names
+        style?: any;
+        size?: number;
+        color?: ColorValue | number;
+      }>;
   iconName?: string;
   iconSize?: number;
   color?: ColorValue;

--- a/src/__tests__/HeaderButtons.test.tsx
+++ b/src/__tests__/HeaderButtons.test.tsx
@@ -71,7 +71,7 @@ describe('HeaderButtons', () => {
     const IoniconsHeaderButton = (props: HeaderButtonProps) => (
       <HeaderButton
         {...props}
-        IconComponent={({ name }) => <Text>{name}</Text>}
+        IconComponent={({ name }: { name: any }) => <Text>{name}</Text>}
         iconSize={23}
         color="blue"
       />


### PR DESCRIPTION
This is a probable fix for https://github.com/vonovak/react-navigation-header-buttons/issues/240

Expand the type of `IconComponent` to support the types employed by `react-native-vector-icons`