### PR TITLE
Misc Typescript fixes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { HeaderButtonsComponentType } from './HeaderButtonComponentContext';
+export { type HeaderButtonsComponentType } from './HeaderButtonComponentContext';
 export {
   HeaderButton,
   defaultRenderVisibleButton,
@@ -6,7 +6,7 @@ export {
   type HeaderButtonProps,
   type VisibleButtonProps,
 } from './HeaderButton';
-export { HeaderButtons, HeaderButtonsProps } from './HeaderButtons';
+export { HeaderButtons, type HeaderButtonsProps } from './HeaderButtons';
 export {
   defaultOnOverflowMenuPress,
   overflowMenuPressHandlerActionSheet,
@@ -14,7 +14,7 @@ export {
   overflowMenuPressHandlerDropdownMenu,
   extractOverflowButtonData,
   extractHiddenItemProps,
-  OnOverflowMenuPressParams,
+  type OnOverflowMenuPressParams,
 } from './overflowMenu/overflowMenuPressHandlers';
 export { Item, HiddenItem, type HiddenItemProps } from './HeaderItems';
 export { useOverflowMenu } from './overflowMenu/OverflowMenuContext';

--- a/src/overflowMenu/overflowMenuPressHandlers.ts
+++ b/src/overflowMenu/overflowMenuPressHandlers.ts
@@ -87,7 +87,7 @@ export const overflowMenuPressHandlerPopupMenu = ({
   overflowButtonRef,
 }: OnOverflowMenuPressParams) => {
   const enabledButtons = hiddenButtons.filter((it) => it.disabled !== true);
-  const presenter = 'showPopupMenu' in UIManager && UIManager.showPopupMenu;
+  const presenter = 'showPopupMenu' in UIManager ? UIManager.showPopupMenu : null;
   const node = findNodeHandle(overflowButtonRef);
   if (!presenter || !node) {
     console.warn(

--- a/src/overflowMenu/overflowMenuPressHandlers.ts
+++ b/src/overflowMenu/overflowMenuPressHandlers.ts
@@ -87,7 +87,7 @@ export const overflowMenuPressHandlerPopupMenu = ({
   overflowButtonRef,
 }: OnOverflowMenuPressParams) => {
   const enabledButtons = hiddenButtons.filter((it) => it.disabled !== true);
-  const presenter = 'showPopupMenu' in UIManager ? UIManager.showPopupMenu : null;
+  const presenter = UIManager.showPopupMenu;
   const node = findNodeHandle(overflowButtonRef);
   if (!presenter || !node) {
     console.warn(

--- a/src/overflowMenu/overflowMenuPressHandlers.ts
+++ b/src/overflowMenu/overflowMenuPressHandlers.ts
@@ -89,7 +89,7 @@ export const overflowMenuPressHandlerPopupMenu = ({
   const enabledButtons = hiddenButtons.filter((it) => it.disabled !== true);
   const presenter = UIManager.showPopupMenu;
   const node = findNodeHandle(overflowButtonRef);
-  if (!presenter || !node) {
+  if (!presenter || typeof presenter !== 'function' || !node) {
     console.warn(
       'could not present overflow menu using showPopupMenu(). Note this is only available on Android.'
     );

--- a/src/overflowMenu/overflowMenuPressHandlers.ts
+++ b/src/overflowMenu/overflowMenuPressHandlers.ts
@@ -87,7 +87,7 @@ export const overflowMenuPressHandlerPopupMenu = ({
   overflowButtonRef,
 }: OnOverflowMenuPressParams) => {
   const enabledButtons = hiddenButtons.filter((it) => it.disabled !== true);
-  const presenter = UIManager.showPopupMenu;
+  const presenter = 'showPopupMenu' in UIManager && UIManager.showPopupMenu;
   const node = findNodeHandle(overflowButtonRef);
   if (!presenter || !node) {
     console.warn(


### PR DESCRIPTION
Discovered that index file does not support isolatedModules
Also, UIManager might not contain a method. Added a check for that too.  
```
node_modules/react-navigation-header-buttons/src/index.ts:1:10 - error TS1205: Re-exporting a type when 'isolatedModules' is enabled requires using 'export type'.

1 export { HeaderButtonsComponentType } from './HeaderButtonComponentContext';
           ~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/react-navigation-header-buttons/src/index.ts:9:25 - error TS1205: Re-exporting a type when 'isolatedModules' is enabled requires using 'export type'.

9 export { HeaderButtons, HeaderButtonsProps } from './HeaderButtons';
                          ~~~~~~~~~~~~~~~~~~

node_modules/react-navigation-header-buttons/src/index.ts:17:3 - error TS1205: Re-exporting a type when 'isolatedModules' is enabled requires using 'export type'.

17   OnOverflowMenuPressParams,
     ~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/react-navigation-header-buttons/src/overflowMenu/overflowMenuPressHandlers.ts:90:31 - error TS2339: Property 'showPopupMenu' does not exist on type 'UIManagerStatic'.

90   const presenter = UIManager.showPopupMenu;
                                 ~~~~~~~~~~~~~

node_modules/react-navigation-header-buttons/src/overflowMenu/vendor/Menu.tsx:254:25 - error TS2584: Cannot find name 'document'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.

254     this.isBrowser() && document.addEventListener('keyup', this.handleKeypress);
                            ~~~~~~~~

node_modules/react-navigation-header-buttons/src/overflowMenu/vendor/Menu.tsx:262:7 - error TS2584: Cannot find name 'document'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.

262       document.removeEventListener('keyup', this.handleKeypress);
          ~~~~~~~~
```
