### PR TITLE
chore: use export type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { HeaderButtonsComponentType } from './HeaderButtonComponentContext';
+export { type HeaderButtonsComponentType } from './HeaderButtonComponentContext';
 export {
   HeaderButton,
   defaultRenderVisibleButton,
@@ -6,7 +6,7 @@ export {
   type HeaderButtonProps,
   type VisibleButtonProps,
 } from './HeaderButton';
-export { HeaderButtons, HeaderButtonsProps } from './HeaderButtons';
+export { HeaderButtons, type HeaderButtonsProps } from './HeaderButtons';
 export {
   defaultOnOverflowMenuPress,
   overflowMenuPressHandlerActionSheet,
@@ -14,7 +14,7 @@ export {
   overflowMenuPressHandlerDropdownMenu,
   extractOverflowButtonData,
   extractHiddenItemProps,
-  OnOverflowMenuPressParams,
+  type OnOverflowMenuPressParams,
 } from './overflowMenu/overflowMenuPressHandlers';
 export { Item, HiddenItem, type HiddenItemProps } from './HeaderItems';
 export { useOverflowMenu } from './overflowMenu/OverflowMenuContext';

--- a/src/overflowMenu/__tests__/OverflowMenuProvider.test.tsx
+++ b/src/overflowMenu/__tests__/OverflowMenuProvider.test.tsx
@@ -168,24 +168,24 @@ describe('HeaderButtonsProvider renders', () => {
 
       // OverflowMenu imports the e2e file which is why it's here
       expect(filteredIos).toMatchInlineSnapshot(`
-      [
-        "HeaderButtonsProvider.tsx",
-        "HeaderButtonsProvider.ios.tsx",
-        "HeaderButtonsProviderPlain.tsx",
-        "ButtonsWrapper.tsx",
-        "index.ts",
-        "HeaderButtonComponentContext.tsx",
-        "HeaderButton.tsx",
-        "HeaderButtons.tsx",
-        "overflowMenuPressHandlers.ts",
-        "HeaderItems.tsx",
-        "OverflowMenuContext.tsx",
-        "MenuItem.tsx",
-        "OverflowMenu.tsx",
-        "e2e.ts",
-        "Divider.tsx",
-      ]
-    `);
+        [
+          "HeaderButtonsProvider.tsx",
+          "HeaderButtonsProvider.ios.tsx",
+          "HeaderButtonsProviderPlain.tsx",
+          "ButtonsWrapper.tsx",
+          "index.ts",
+          "HeaderButton.tsx",
+          "HeaderButtons.tsx",
+          "HeaderButtonComponentContext.tsx",
+          "overflowMenuPressHandlers.ts",
+          "HeaderItems.tsx",
+          "OverflowMenuContext.tsx",
+          "MenuItem.tsx",
+          "OverflowMenu.tsx",
+          "e2e.ts",
+          "Divider.tsx",
+        ]
+      `);
     },
     20000
   );


### PR DESCRIPTION
Added a `type` to exports in the index file to support enabled `isolatedModules` flag.